### PR TITLE
Add hooks

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/e285f1230dea6e4dc7806298e7916e0c73157701/schemas/v1.0/azure.yaml.json
 
 name: modern-dev-environment-demo
 services:
@@ -14,3 +14,10 @@ services:
         docker:
             path: Dockerfile
         host: containerapp
+hooks:
+    postprovision:
+        run: ./scripts/update-ui.sh
+        interactive: true
+    postdeploy:
+        run: ./scripts/validate.sh
+        interactive: true

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -143,6 +143,7 @@ module ui 'ui.bicep' = {
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = registry.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
 output AZURE_CONTAINER_REGISTRY_NAME string = registry.outputs.AZURE_CONTAINER_REGISTRY_NAME
 output APP_API_BASE_URL string = api.outputs.API_URI
+output APP_UI_BASE_URL string = ui.outputs.UI_URI
 output SQL_NAME string = 'sql-${resourceToken}'
 output MANAGED_IDENTITY_NAME string = managedIdentityName
 output SQL_PASSWORD string = sqlPassword

--- a/scripts/get-all.sh
+++ b/scripts/get-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export $(azd env get-values | grep -i API_URI | tr -d '\"')
+export $(azd env get-values | grep -i APP_API_BASE_URL | tr -d '\"')
 
 echo Get All
-curl -s ${API_URI}/todos | jq
+curl -s ${APP_API_BASE_URL}/todos | jq

--- a/scripts/update-ui.sh
+++ b/scripts/update-ui.sh
@@ -4,9 +4,6 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 SRC_PATH=$(realpath "${SCRIPT_DIR}/../src/ui/wwwroot")
 APP_SETTINGS_FILE="${SRC_PATH}/appsettings.json"
 
-export $(azd env get-values | grep -i APP_API_BASE_URL | tr -d '\"')
-export $(azd env get-values | grep -i APP_UI_BASE_URL | tr -d '\"')
-
 cat << EOF > $APP_SETTINGS_FILE
 {
     "API_URI": "${APP_API_BASE_URL}"

--- a/scripts/update-ui.sh
+++ b/scripts/update-ui.sh
@@ -2,14 +2,15 @@
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 SRC_PATH=$(realpath "${SCRIPT_DIR}/../src/ui/wwwroot")
+APP_SETTINGS_FILE="${SRC_PATH}/appsettings.json"
 
-export $(azd env get-values | grep -i API_URI | tr -d '\"')
-export $(azd env get-values | grep -i UI_URI | tr -d '\"')
+export $(azd env get-values | grep -i APP_API_BASE_URL | tr -d '\"')
+export $(azd env get-values | grep -i APP_UI_BASE_URL | tr -d '\"')
 
-cat << EOF > ${SRC_PATH}/appsettings.json
+cat << EOF > $APP_SETTINGS_FILE
 {
-    "API_URI": "${API_URI}"
+    "API_URI": "${APP_API_BASE_URL}"
 }
 EOF
 
-azd deploy --cwd ${SCRIPT_DIR}/.. --service ui
+echo "Updated ${APP_SETTINGS_FILE}"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
-export $(azd env get-values | grep -i API_URI | tr -d '\"')
+export $(azd env get-values | grep -i APP_API_BASE_URL | tr -d '\"')
 
 echo Health Check
-curl -w '\n' ${API_URI}/
+curl -w '\n' ${APP_API_BASE_URL}/
 
 echo Post Sample Items
-curl -sX POST ${API_URI}/todos/ -d '{"Id": "123456", "Name": "Take out trash"}' -H "Content-Type: application/json" 
-curl -sX POST ${API_URI}/todos/ -d '{"Id": "7891011", "Name": "Clean your bathroom"}' -H "Content-Type: application/json" 
+curl -sX POST ${APP_API_BASE_URL}/todos/ -d '{"Id": "123456", "Name": "Take out trash"}' -H "Content-Type: application/json" 
+curl -sX POST ${APP_API_BASE_URL}/todos/ -d '{"Id": "7891011", "Name": "Clean your bathroom"}' -H "Content-Type: application/json" 
 echo
 
 echo Get Todo ID# 123456
-curl -s ${API_URI}/todos/123456 | jq
+curl -s ${APP_API_BASE_URL}/todos/123456 | jq
 
 echo Update Todo# 7891011
-curl -sX PUT ${API_URI}/todos/7891011 -d '{"Id": "7891011", "Name": "Clean your bathroom", "IsComplete": true }' -H "Content-Type: application/json" 
-curl -s ${API_URI}/todos/7891011 | jq
+curl -sX PUT ${APP_API_BASE_URL}/todos/7891011 -d '{"Id": "7891011", "Name": "Clean your bathroom", "IsComplete": true }' -H "Content-Type: application/json" 
+curl -s ${APP_API_BASE_URL}/todos/7891011 | jq
 
 echo Get All
-curl -s ${API_URI}/todos | jq
+curl -s ${APP_API_BASE_URL}/todos | jq

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export $(azd env get-values | grep -i APP_API_BASE_URL | tr -d '\"')
-
 echo Health Check
 curl -w '\n' ${APP_API_BASE_URL}/
 


### PR DESCRIPTION
With this PR:
https://github.com/Azure/azure-dev/pull/1429

We are adding script hooks feature that allows you to specifiy scripts to be run pre/post azd commands.

I updated azure.yaml to include postprovision and postdeploy hooks.

You should now just be able to run `azd up` without manually running update-ui.sh

You can test by installing the cli from here: 
https://github.com/Azure/azure-dev/pull/1429#issuecomment-1402432165

We'll want to update the azure.yaml schema reference before merging.

